### PR TITLE
feat: allow custom dmenu programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Built with Nix](https://img.shields.io/badge/Nix-Flake-blue.svg?logo=nixos&logoColor=white)](https://nixos.org)
 [![Language: Rust](https://img.shields.io/badge/Language-Rust-orange.svg?logo=rust)](https://www.rust-lang.org)
 
-**A high-performance, system-wide color picker for Linux (Wayland & X11).**  
+**A high-performance, system-wide color picker for Linux (Wayland & X11).**
 Click → Color → Done. Zero latency, pixel-perfect precision.
 
 ---
@@ -154,7 +154,7 @@ cp ~/.local/share/applications/ie-r.desktop ~/.config/autostart/
 
 ### Configuration
 
-All settings live in `~/.config/ie-r/config.toml`. The file is created with defaults on first run. IE-R preserves your comments when updating the config.
+Settings live in `~/.config/ie-r/config.toml`. Picked color history lives in `~/.local/state/ie-r/history.toml`. Both files are created as needed on first run, and IE-R preserves your comments when updating the config.
 
 ---
 

--- a/README.portable.md
+++ b/README.portable.md
@@ -62,7 +62,7 @@ bindsym Alt+Shift+h exec pkill -SIGUSR2 ie-r
 
 ## Configuration
 
-All settings live in `~/.config/ie-r/config.toml`. Created with defaults on first run. IE-R preserves your comments when updating the config.
+Settings live in `~/.config/ie-r/config.toml`. Picked color history lives in `~/.local/state/ie-r/history.toml`. Files are created as needed on first run, and IE-R preserves your comments when updating the config.
 
 ---
 

--- a/src/core/color_service.rs
+++ b/src/core/color_service.rs
@@ -135,7 +135,7 @@ impl ColorService {
     /// Four steps (always in this order):
     ///   1. Sync   — merge changed fields from overlay_config back into self.config
     ///   2. Copy   — if colors picked: clipboard + history; otherwise log "cancelled"
-    ///   3. Save   — single disk write: config + history together
+    ///   3. Save   — coordinated persistence: config.toml + history.toml
     ///   4. Notify — update tray menu from the already-current self.config
     pub fn finalize_overlay(&mut self, overlay_config: &crate::core::config::Config, color_deck: Vec<image::Rgba<u8>>) {
         //    Sync: optics/HUD/format settings from overlay → daemon config
@@ -153,7 +153,7 @@ impl ColorService {
             log_info("Selection cancelled.");
         }
 
-        //    Save: single disk write (settings + history)
+        //    Save: persist settings and history to their respective files
         self.config.save();
         log_success("Saved", "Configuration and history updated");
 

--- a/src/core/color_service.rs
+++ b/src/core/color_service.rs
@@ -29,6 +29,7 @@ pub struct ColorService {
 impl ColorService {
     pub fn new() -> Self {
         let config = Config::load(false);
+        crate::daemon::dbus_menu::DBusMenu::prime_layout_state(&config);
         let clipboard = Clipboard::new().ok();
         let dbus_conn = zbus::blocking::Connection::session().ok();
 
@@ -63,6 +64,7 @@ impl ColorService {
 
         self.config = Config::load(true);
         log_info("Configuration hot-reloaded");
+        crate::daemon::dbus_menu::DBusMenu::notify_layout_update(&self.config);
         perf.log("Config loaded");
 
         // Font hot-reload: if font family changed, search in the already-loaded database.

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -280,6 +280,8 @@ pub struct SystemConfig {
     pub auto_cancel: u64,
     #[serde(default)]
     pub tray_icon: TrayIcon,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub menu_command: Option<Vec<String>>,
 }
 
 // --- Hex Color Serializer/Deserializer ---
@@ -377,6 +379,29 @@ impl Config {
         base.join("ie-r").join("config.toml")
     }
 
+    fn parse_menu_command_from_str(content: &str) -> Option<Option<Vec<String>>> {
+        let doc = content.parse::<toml_edit::DocumentMut>().ok()?;
+        let item = doc.get("system").and_then(|system| system.get("menu_command"));
+
+        match item {
+            Some(item) if item.is_none() => Some(None),
+            Some(item) => {
+                let arr = item.as_array()?;
+                let mut command = Vec::with_capacity(arr.len());
+                for value in arr.iter() {
+                    command.push(value.as_str()?.to_string());
+                }
+                Some(Some(command))
+            }
+            None => Some(None),
+        }
+    }
+
+    pub fn read_menu_command_from_disk() -> Option<Option<Vec<String>>> {
+        let content = fs::read_to_string(Self::get_config_path()).ok()?;
+        Self::parse_menu_command_from_str(&content)
+    }
+
     fn backup_broken_config(path: &std::path::Path) {
         if !path.exists() {
             return;
@@ -436,7 +461,12 @@ impl Config {
             }
         };
 
-        let Ok(new_toml_str) = toml_edit::ser::to_string(self) else { return };
+        let mut merged = self.clone();
+        if let Some(menu_command) = Self::parse_menu_command_from_str(&existing_content) {
+            merged.system.menu_command = menu_command;
+        }
+
+        let Ok(new_toml_str) = toml_edit::ser::to_string(&merged) else { return };
         let Ok(new_doc) = new_toml_str.parse::<toml_edit::DocumentMut>() else { return };
 
         let root = doc.as_table_mut();

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io::ErrorKind;
 use crate::core::terminal::{log_step, log_warn, log_error};
 
 // ==============================================================================
@@ -252,8 +253,14 @@ pub struct HistoryConfig {
     pub size: usize,
     #[serde(default = "default_history_reverse")]
     pub reverse_order: bool,
-    #[serde(default = "default_history_colors")]
+    #[serde(default = "default_history_colors", skip_serializing)]
     pub colors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PersistedHistory {
+    #[serde(default = "default_history_colors")]
+    colors: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -379,6 +386,13 @@ impl Config {
         base.join("ie-r").join("config.toml")
     }
 
+    pub fn get_history_path() -> std::path::PathBuf {
+        let base = std::env::var("XDG_STATE_HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| dirs_next().join(".local").join("state"));
+        base.join("ie-r").join("history.toml")
+    }
+
     fn parse_menu_command_from_str(content: &str) -> Option<Option<Vec<String>>> {
         let doc = content.parse::<toml_edit::DocumentMut>().ok()?;
         let item = doc.get("system").and_then(|system| system.get("menu_command"));
@@ -402,36 +416,79 @@ impl Config {
         Self::parse_menu_command_from_str(&content)
     }
 
-    fn backup_broken_config(path: &std::path::Path) {
+    fn backup_broken_file(path: &std::path::Path, prefix: &str) {
         if !path.exists() {
             return;
         }
         if let Some(dir) = path.parent() {
             for idx in 1..=99 {
-                let backup_path = dir.join(format!("config_broken_{:02}.toml", idx));
+                let backup_path = dir.join(format!("{}_broken_{:02}.toml", prefix, idx));
                 if !backup_path.exists() {
                     if let Ok(_) = fs::rename(path, &backup_path) {
-                        log_step("Config", &format!("Broken config moved to {:?}", backup_path));
+                        log_step("Config", &format!("Broken {} moved to {:?}", prefix, backup_path));
                     }
                     return;
                 }
             }
-            log_error("Too many broken configs! Backup skipped.");
+            log_error(&format!("Too many broken {} files! Backup skipped.", prefix));
         }
+    }
+
+    fn load_history_colors(path: &std::path::Path, legacy_colors: Vec<String>) -> Vec<String> {
+        match fs::read_to_string(path) {
+            Ok(content) => match toml_edit::de::from_str::<PersistedHistory>(&content) {
+                Ok(history) => history.colors,
+                Err(e) => {
+                    log_error(&format!("Error parsing {:?}: {}", path, e));
+                    Self::backup_broken_file(path, "history");
+                    log_warn("Falling back to config-embedded history.");
+                    legacy_colors
+                }
+            },
+            Err(e) if e.kind() == ErrorKind::NotFound => legacy_colors,
+            Err(e) => {
+                log_error(&format!("Error reading {:?}: {}", path, e));
+                log_warn("Falling back to config-embedded history.");
+                legacy_colors
+            }
+        }
+    }
+
+    fn save_history(&self) -> Result<(), String> {
+        let path = Self::get_history_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Error creating history directory {:?}: {}", parent, e))?;
+        }
+
+        let persisted = PersistedHistory {
+            colors: self.history.colors.clone(),
+        };
+
+        let toml = toml_edit::ser::to_string(&persisted)
+            .map_err(|e| format!("Error serializing {:?}: {}", path, e))?;
+        fs::write(&path, toml)
+            .map_err(|e| format!("Error writing {:?}: {}", path, e))?;
+        log_step("Config", &format!("Saved history: {:?}", path));
+        Ok(())
     }
 
     /// Loads config from disk. Falls back to defaults if the file is missing or invalid.
     pub fn load(silent: bool) -> Self {
         let path = Self::get_config_path();
-        if let Ok(content) = fs::read_to_string(&path) {
-            match toml_edit::de::from_str(&content) {
-                Ok(config) => {
+        let mut loaded_from_config = false;
+        let mut config = if let Ok(content) = fs::read_to_string(&path) {
+            match toml_edit::de::from_str::<Config>(&content) {
+                Ok(mut config) => {
+                    loaded_from_config = true;
                     if !silent { log_step("Config", &format!("Target confirmed: {:?}", path)); }
+                    let legacy_colors = config.history.colors.clone();
+                    config.history.colors = Self::load_history_colors(&Self::get_history_path(), legacy_colors);
                     config
                 }
                 Err(e) => {
                     log_error(&format!("Error parsing {:?}: {}", path, e));
-                    Self::backup_broken_config(&path);
+                    Self::backup_broken_file(&path, "config");
                     log_warn("Falling back to defaults. Backup created.");
                     let _ = fs::write(&path, DEFAULT_CONFIG_TEMPLATE);
                     Self::default()
@@ -442,10 +499,15 @@ impl Config {
             let _ = fs::write(&path, DEFAULT_CONFIG_TEMPLATE);
             log_step("Config", &format!("Initialized new config from template: {:?}", path));
             Self::default()
+        };
+
+        if !loaded_from_config && config.history.colors.is_empty() {
+            config.history.colors = Self::load_history_colors(&Self::get_history_path(), Vec::new());
         }
+        config
     }
 
-    /// Surgically saves current settings to disk, preserving user comments.
+    /// Surgically saves current settings to disk, preserving user comments in config.toml.
     pub fn save(&self) {
         let path = Self::get_config_path();
         if let Some(parent) = path.parent() { let _ = fs::create_dir_all(parent); }
@@ -456,7 +518,7 @@ impl Config {
             Ok(d) => d,
             Err(_) => {
                 log_warn("Repairing corrupted config using template foundation...");
-                Self::backup_broken_config(&path);
+                Self::backup_broken_file(&path, "config");
                 DEFAULT_CONFIG_TEMPLATE.parse::<toml_edit::DocumentMut>().unwrap_or_default()
             }
         };
@@ -478,6 +540,16 @@ impl Config {
                 if let Some(t) = new_item.as_table_mut() { t.set_implicit(true); }
                 root.insert(key, new_item);
             }
+        }
+        let history_saved = match self.save_history() {
+            Ok(()) => true,
+            Err(e) => {
+                log_error(&e);
+                false
+            }
+        };
+        if history_saved || !has_history_colors(root) {
+            remove_history_colors(root);
         }
         if fs::write(&path, doc.to_string()).is_ok() {
             log_step("Config", &format!("Saved changes: {:?}", path));
@@ -575,6 +647,19 @@ fn update_toml_item(target: &mut toml_edit::Item, source: &toml_edit::Item) {
     } else {
         *target = source.clone();
     }
+}
+
+fn remove_history_colors(root: &mut toml_edit::Table) {
+    if let Some(history) = root.get_mut("history").and_then(|item| item.as_table_mut()) {
+        history.remove("colors");
+    }
+}
+
+fn has_history_colors(root: &toml_edit::Table) -> bool {
+    root.get("history")
+        .and_then(|item| item.as_table())
+        .and_then(|history| history.get("colors"))
+        .is_some()
 }
 
 fn dirs_next() -> std::path::PathBuf {

--- a/src/core/default_config.toml
+++ b/src/core/default_config.toml
@@ -113,10 +113,17 @@ colors = []
 # "none"       — disable tray entirely. SNI is not registered.
 tray_icon = "color"
 
-# Inactivity watchdog timeout (seconds). 
+# Inactivity watchdog timeout (seconds).
 # Automatically cancels the overlay if no movement/input is detected.
 # Set to 0 to disable. (default: 60)
 auto_cancel = 60
+
+# Optional external menu override for wlroots/Wayland popup fallback.
+# Format: TOML string array, where the first item is the executable and the rest are args.
+# Example: menu_command = ["dmenu", "-i", "-p", "IE-R"]
+# No shell parsing or environment expansion is performed here.
+# Leave unset to auto-detect: rofi -> wofi -> fuzzel.
+# menu_command = ["dmenu", "-i", "-p", "IE-R"]
 
 # --- X11 Environments ONLY ---
 # Under X11, the daemon actively polls the keyboard for this hotkey.

--- a/src/core/default_config.toml
+++ b/src/core/default_config.toml
@@ -96,11 +96,11 @@ hsv     = "{h}, {s}%, {v}%"
 cmyk    = "{c}%, {m}%, {y}%, {k}%"
 
 # Color history is shown in the system tray context menu.
-# Managed automatically — don't edit the colors array by hand.
+# Settings live here; picked colors themselves are stored separately in
+# ~/.local/state/ie-r/history.toml (or $XDG_STATE_HOME/ie-r/history.toml).
 [history]
 size = 10             # max colors to remember
 reverse_order = true  # newest first in tray menu
-colors = []
 
 # Global system integration settings.
 [system]

--- a/src/daemon/dbus_menu.rs
+++ b/src/daemon/dbus_menu.rs
@@ -37,6 +37,8 @@ struct MenuState {
     history: Vec<String>,
     /// History reversal flag. Applied on each MenuSnapshot::take().
     reverse_order: bool,
+    /// Optional external launcher override for wlroots popup fallback.
+    menu_command: Option<Vec<String>>,
     /// Selected format template key (e.g. "hex", "rgb", "hsl").
     selected_template: String,
     /// HUD visibility state (the "Show HUD" checkbox in the menu).
@@ -51,6 +53,7 @@ impl MenuState {
         Self {
             history: Vec::new(),
             reverse_order: false,
+            menu_command: None,
             selected_template: String::new(),
             show_hud: true,
             png_cache: HashMap::new(),
@@ -64,6 +67,7 @@ static MENU_STATE: LazyLock<RwLock<MenuState>> = LazyLock::new(|| RwLock::new(Me
 /// Read from caches (not disk), guaranteed consistent.
 pub struct MenuSnapshot {
     pub history: Vec<String>,
+    pub menu_command: Option<Vec<String>>,
     pub selected_template: String,
     pub show_hud: bool,
 }
@@ -79,6 +83,7 @@ impl MenuSnapshot {
         };
         Self {
             history,
+            menu_command: state.menu_command.clone(),
             selected_template: state.selected_template.clone(),
             show_hud: state.show_hud,
         }
@@ -337,15 +342,18 @@ impl DBusMenu {
 }
 
 impl DBusMenu {
+    fn sync_state(config: &crate::core::config::Config) {
+        let mut state = MENU_STATE.write().unwrap();
+        state.history = config.history.colors.clone();
+        state.reverse_order = config.history.reverse_order;
+        state.menu_command = config.system.menu_command.clone();
+        state.selected_template = config.templates.selected.clone();
+        state.show_hud = config.hud.show;
+    }
+
     pub fn new(proxy: EventSender) -> Self {
         let config = crate::core::config::Config::load(true);
-        {
-            let mut state = MENU_STATE.write().unwrap();
-            state.history = config.history.colors;
-            state.reverse_order = config.history.reverse_order;
-            state.selected_template = config.templates.selected.clone();
-            state.show_hud = config.hud.show;
-        }
+        Self::sync_state(&config);
 
         Self {
             proxy,
@@ -361,14 +369,11 @@ impl DBusMenu {
     /// Accepts a ready config — no disk read (data is current after save()).
     pub fn notify_layout_update(config: &crate::core::config::Config) {
         {
-            let mut state = MENU_STATE.write().unwrap();
-            state.history = config.history.colors.clone();
-            state.reverse_order = config.history.reverse_order;
-            state.selected_template = config.templates.selected.clone();
-            state.show_hud = config.hud.show;
+            Self::sync_state(config);
             // Prune PNG cache: remove icons for colors no longer in history.
             // Without this the cache grows unboundedly over long daemon runs.
             // Stale keys are collected separately to avoid borrow conflict with history.
+            let mut state = MENU_STATE.write().unwrap();
             let stale: Vec<String> = state.png_cache.keys()
                 .filter(|hex| !state.history.contains(hex))
                 .cloned()
@@ -378,6 +383,10 @@ impl DBusMenu {
             }
         }
         Self::emit_layout_signal();
+    }
+
+    pub fn prime_layout_state(config: &crate::core::config::Config) {
+        Self::sync_state(config);
     }
 
     /// Updates only the selected template (without touching history).

--- a/src/daemon/rofi_menu.rs
+++ b/src/daemon/rofi_menu.rs
@@ -1,4 +1,4 @@
-/// Rofi/wofi/fuzzel fallback menu for wlroots-based compositors.
+/// External launcher menu for wlroots-based compositors.
 ///
 /// On KDE/GNOME the tray host renders dbusmenu popups natively.
 /// On wlroots (Hyprland, Sway, niri, river…) GTK3 can't spawn a popup
@@ -6,7 +6,10 @@
 
 use super::UserEvent;
 use super::event_sender::EventSender;
+use crate::core::config::Config;
+use crate::core::config::TEMPLATE_LABELS;
 use crate::core::terminal::log_error;
+use crate::daemon::dbus_menu::MenuSnapshot;
 
 /// Desktop environments known to render dbusmenu popups natively.
 /// Everything else gets the external menu fallback.
@@ -20,30 +23,99 @@ pub fn has_native_popup() -> bool {
     desktop.split(':').any(|d| NATIVE_POPUP_DESKTOPS.contains(&d))
 }
 
-/// Show the context menu via an external launcher (rofi → wofi → fuzzel).
-pub async fn show_menu(proxy: EventSender) {
-    use crate::core::config::TEMPLATE_LABELS;
-    use crate::daemon::dbus_menu::MenuSnapshot;
-    use tokio::io::AsyncWriteExt;
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Action {
+    History(String),
+    Template(String),
+    ToggleHUD,
+    EditConfig,
+    About,
+    Homepage,
+    Quit,
+}
 
-    let snap = MenuSnapshot::take();
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MenuInputMode {
+    Plain,
+    RofiIcons,
+}
 
-    enum Action {
-        History(String),
-        Template(String),
-        ToggleHUD,
-        EditConfig,
-        About,
-        Homepage,
-        Quit,
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LauncherSpec {
+    cmd: String,
+    args: Vec<String>,
+    input_mode: MenuInputMode,
+    custom: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MenuEntry {
+    label: String,
+    rofi_line: Option<String>,
+    action: Action,
+}
+
+impl MenuEntry {
+    fn line_for(&self, mode: MenuInputMode) -> &str {
+        match mode {
+            MenuInputMode::Plain => &self.label,
+            MenuInputMode::RofiIcons => self.rofi_line.as_deref().unwrap_or(&self.label),
+        }
+    }
+}
+
+fn resolve_launchers(menu_command: Option<&[String]>) -> Result<Vec<LauncherSpec>, String> {
+    if let Some(command) = menu_command {
+        if command.is_empty() {
+            return Err("Invalid config: system.menu_command must contain an executable.".to_string());
+        }
+
+        let executable = command[0].trim();
+        if executable.is_empty() {
+            return Err("Invalid config: system.menu_command[0] must be a non-empty executable.".to_string());
+        }
+
+        return Ok(vec![LauncherSpec {
+            cmd: executable.to_string(),
+            args: command[1..].to_vec(),
+            input_mode: MenuInputMode::Plain,
+            custom: true,
+        }]);
     }
 
-    // Prepare temp dir for color swatch PNGs (rofi icon support)
+    Ok(vec![
+        LauncherSpec {
+            cmd: "rofi".to_string(),
+            args: vec![
+                "-dmenu".to_string(),
+                "-p".to_string(),
+                "IE-R".to_string(),
+                "-no-custom".to_string(),
+                "-show-icons".to_string(),
+            ],
+            input_mode: MenuInputMode::RofiIcons,
+            custom: false,
+        },
+        LauncherSpec {
+            cmd: "wofi".to_string(),
+            args: vec!["--dmenu".to_string(), "--prompt".to_string(), "IE-R".to_string()],
+            input_mode: MenuInputMode::Plain,
+            custom: false,
+        },
+        LauncherSpec {
+            cmd: "fuzzel".to_string(),
+            args: vec!["--dmenu".to_string(), "--prompt".to_string(), "IE-R ".to_string()],
+            input_mode: MenuInputMode::Plain,
+            custom: false,
+        },
+    ])
+}
+
+fn build_menu_entries(snap: &MenuSnapshot) -> Vec<MenuEntry> {
+    let mut entries = Vec::new();
+
     let color_icon_dir = std::path::PathBuf::from("/tmp/ie-r-colors");
     let _ = std::fs::create_dir_all(&color_icon_dir);
-
-    let mut lines: Vec<String> = Vec::new();
-    let mut actions: Vec<Action> = Vec::new();
 
     for hex in &snap.history {
         let filename = format!("{}.png", hex.trim_start_matches('#'));
@@ -52,88 +124,129 @@ pub async fn show_menu(proxy: EventSender) {
             let png = crate::daemon::dbus_menu::generate_color_png(hex);
             let _ = std::fs::write(&icon_path, &png);
         }
-        lines.push(format!("{}\0icon\x1f{}", hex, icon_path.display()));
-        actions.push(Action::History(hex.clone()));
+
+        entries.push(MenuEntry {
+            label: hex.clone(),
+            rofi_line: Some(format!("{}\0icon\x1f{}", hex, icon_path.display())),
+            action: Action::History(hex.clone()),
+        });
     }
 
     for &(key, label) in TEMPLATE_LABELS {
         let dot = if snap.selected_template == key { "●" } else { "○" };
-        lines.push(format!("{} {}", dot, label));
-        actions.push(Action::Template(key.to_string()));
+        entries.push(MenuEntry {
+            label: format!("{} {}", dot, label),
+            rofi_line: None,
+            action: Action::Template(key.to_string()),
+        });
     }
 
     let hud_dot = if snap.show_hud { "✓" } else { "○" };
-    lines.push(format!("{} Show HUD", hud_dot));
-    actions.push(Action::ToggleHUD);
+    entries.push(MenuEntry {
+        label: format!("{} Show HUD", hud_dot),
+        rofi_line: None,
+        action: Action::ToggleHUD,
+    });
+    entries.push(MenuEntry {
+        label: "⚙ Edit Config".to_string(),
+        rofi_line: None,
+        action: Action::EditConfig,
+    });
+    entries.push(MenuEntry {
+        label: "🌐 Homepage".to_string(),
+        rofi_line: None,
+        action: Action::Homepage,
+    });
+    entries.push(MenuEntry {
+        label: "ℹ About".to_string(),
+        rofi_line: None,
+        action: Action::About,
+    });
+    entries.push(MenuEntry {
+        label: "✕ Quit".to_string(),
+        rofi_line: None,
+        action: Action::Quit,
+    });
 
-    lines.push("⚙ Edit Config".to_string());
-    actions.push(Action::EditConfig);
+    entries
+}
 
-    lines.push("🌐 Homepage".to_string());
-    actions.push(Action::Homepage);
+fn build_menu_input(entries: &[MenuEntry], mode: MenuInputMode) -> String {
+    entries.iter().map(|entry| entry.line_for(mode)).collect::<Vec<_>>().join("\n")
+}
 
-    lines.push("ℹ About".to_string());
-    actions.push(Action::About);
-
-    lines.push("✕ Quit".to_string());
-    actions.push(Action::Quit);
-
-    let input = lines.join("\n");
-
-    // Fallback chain: rofi → wofi → fuzzel
-    let launchers: &[(&str, &[&str])] = &[
-        ("rofi",   &["-dmenu", "-p", "IE-R", "-format", "i", "-no-custom", "-show-icons"]),
-        ("wofi",   &["--dmenu", "--prompt", "IE-R"]),
-        ("fuzzel", &["--dmenu", "--prompt", "IE-R "]),
-    ];
-
-    let mut child = None;
-    for (cmd, args) in launchers {
-        match tokio::process::Command::new(cmd)
-            .args(*args)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .spawn()
-        {
-            Ok(c) => { child = Some(c); break; }
-            Err(_) => continue,
-        }
+fn resolve_action(selection: &str, entries: &[MenuEntry]) -> Option<Action> {
+    let normalized = selection.split('\0').next().unwrap_or(selection).trim();
+    if normalized.is_empty() {
+        return None;
     }
 
-    let mut child = match child {
-        Some(c) => c,
-        None => {
-            log_error("No menu launcher found. Install rofi, wofi, or fuzzel.");
+    if let Ok(idx) = normalized.parse::<usize>() {
+        return entries.get(idx).map(|entry| entry.action.clone());
+    }
+
+    entries.iter().find(|entry| entry.label == normalized).map(|entry| entry.action.clone())
+}
+
+fn dispatch_action(proxy: &EventSender, action: Action) {
+    match action {
+        Action::History(hex)  => { let _ = proxy.send(UserEvent::CopyFromHistory(hex)); }
+        Action::Template(key) => { let _ = proxy.send(UserEvent::SelectTemplate(key)); }
+        Action::ToggleHUD     => { let _ = proxy.send(UserEvent::ToggleHUD); }
+        Action::EditConfig    => { let _ = proxy.send(UserEvent::EditConfig); }
+        Action::About         => { let _ = proxy.send(UserEvent::ShowAbout); }
+        Action::Homepage      => { let _ = proxy.send(UserEvent::OpenHomepage); }
+        Action::Quit          => { let _ = proxy.send(UserEvent::Quit); }
+    }
+}
+
+/// Show the context menu via an external launcher (custom command or rofi → wofi → fuzzel).
+pub async fn show_menu(proxy: EventSender) {
+    use tokio::io::AsyncWriteExt;
+
+    let snap = MenuSnapshot::take();
+    let entries = build_menu_entries(&snap);
+    let menu_command = Config::read_menu_command_from_disk().unwrap_or(snap.menu_command);
+    let launchers = match resolve_launchers(menu_command.as_deref()) {
+        Ok(launchers) => launchers,
+        Err(err) => {
+            log_error(&err);
             return;
         }
     };
 
-    if let Some(mut stdin) = child.stdin.take() {
-        let _ = stdin.write_all(input.as_bytes()).await;
-    }
+    for launcher in launchers {
+        let input = build_menu_input(&entries, launcher.input_mode);
 
-    let out = match child.wait_with_output().await {
-        Ok(o) => o,
-        Err(e) => { log_error(&format!("menu launcher failed: {}", e)); return; }
-    };
+        let mut child = match tokio::process::Command::new(&launcher.cmd)
+            .args(&launcher.args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) if launcher.custom => {
+                log_error(&format!("Custom menu launcher failed to spawn ({}): {}", launcher.cmd, err));
+                return;
+            }
+            Err(_) => continue,
+        };
 
-    let idx_str = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if idx_str.is_empty() { return; }
-
-    let idx: usize = match idx_str.parse() {
-        Ok(i) => i,
-        Err(_) => return,
-    };
-
-    if let Some(action) = actions.into_iter().nth(idx) {
-        match action {
-            Action::History(hex)  => { let _ = proxy.send(UserEvent::CopyFromHistory(hex)); }
-            Action::Template(key) => { let _ = proxy.send(UserEvent::SelectTemplate(key)); }
-            Action::ToggleHUD     => { let _ = proxy.send(UserEvent::ToggleHUD); }
-            Action::EditConfig    => { let _ = proxy.send(UserEvent::EditConfig); }
-            Action::About         => { let _ = proxy.send(UserEvent::ShowAbout); }
-            Action::Homepage      => { let _ = proxy.send(UserEvent::OpenHomepage); }
-            Action::Quit          => { let _ = proxy.send(UserEvent::Quit); }
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(input.as_bytes()).await;
         }
+
+        let out = match child.wait_with_output().await {
+            Ok(output) => output,
+            Err(err) => { log_error(&format!("menu launcher failed: {}", err)); return; }
+        };
+
+        let selection = String::from_utf8_lossy(&out.stdout);
+        if let Some(action) = resolve_action(&selection, &entries) {
+            dispatch_action(&proxy, action);
+        }
+        return;
     }
+
+    log_error("No menu launcher found. Install rofi, wofi, or fuzzel, or set system.menu_command.");
 }


### PR DESCRIPTION
This PR adds ability to use custom dmenu utilities instead of hardcoded ones.

Adds `[system].menu_command` option that accepts custom commands in args array style. Default behavior is unchanged.

Setting up Vicinae as a custom dmenu utility will look as follows:
```toml
[system]
menu_command = ["vicinae", "dmenu", "-p", "IE-R"]
```

This PR also makes history and config as two separate files. This allows using config in the Nix-way - read-only by default - while preserving history functionality for such use case.

<img width="776" height="485" alt="image" src="https://github.com/user-attachments/assets/00bc82a8-60e3-4f30-8579-debb24601a44" />
